### PR TITLE
Fix Copy To Clipboard feature

### DIFF
--- a/public/css/style.css
+++ b/public/css/style.css
@@ -601,15 +601,6 @@ img{
   border-radius: 50px;
 }
 
-a.zeroclipboard-is-hover{
-  color: white;
-  text-decoration: none;
-}
-
-.data .sharelocked-date .clipboard a.zeroclipboard-is-hover i{
-  background-image: url(../images/ico_data_hover.svg) ;
-}
-
 .mobile-con {
   display: none;
 }

--- a/views/data.html
+++ b/views/data.html
@@ -46,16 +46,14 @@
 {% endblock %}
 
 {% block scripts %}
-<script src="//cdnjs.cloudflare.com/ajax/libs/zeroclipboard/2.2.0/ZeroClipboard.min.js"></script>
+<script src="//cdnjs.cloudflare.com/ajax/libs/clipboard.js/2.0.0/clipboard.min.js"></script>
 <script type="text/javascript">
 $(function () {
-  var copy_client = new ZeroClipboard(document.getElementById('copy'));
+  var copy_client = new ClipboardJS(document.getElementById('copy'));
 
-  copy_client.on( "ready", function( readyEvent ) {
-    copy_client.on( "aftercopy", function( event ) {
-      $(event.target).find('.copy_text').text('Copied');
-    } );
-  } );
+  copy_client.on("success", function(event) {
+    $(event.trigger).find('.copy_text').text('Copied');
+  });
 
   $('.link.sharelock').attr('href', location.href);
   $('.link.sharelock').text(location.href);

--- a/views/new.html
+++ b/views/new.html
@@ -89,10 +89,10 @@
 {% endblock %}
 
 {% block scripts %}
-<script src="//cdnjs.cloudflare.com/ajax/libs/zeroclipboard/2.2.0/ZeroClipboard.min.js"></script>
+<script src="//cdnjs.cloudflare.com/ajax/libs/clipboard.js/2.0.0/clipboard.min.js"></script>
 <script type="text/javascript">
 $(function () {
-  var copy_client = new ZeroClipboard(document.getElementById('copy'));
+  var copy_client = new ClipboardJS(document.getElementById('copy'));
 
   $('.link.sharelock').attr('href', location.href);
   $('.link.sharelock').text(location.href);
@@ -203,11 +203,10 @@ $(function () {
     }
   });
 
-  copy_client.on( "ready", function( readyEvent ) {
-    copy_client.on( "aftercopy", function( event ) {
-      $(event.target).find('.copy_text').text('Copied');
-    } );
-  } );
+  copy_client.on("success", function(event) {
+    $(event.trigger).find('.copy_text').text('Copied');
+  });
+
   setTimeout(function() {
     $('#data').focus();
   },0);


### PR DESCRIPTION
The copy-to-clipboard feature is not working. 
This PR migrates from zeroclipboard (deprecated/not working) to [clipboard.js](url)

Changes tested on the _new_ secret view:
![image](https://user-images.githubusercontent.com/11925502/44176236-706a1c00-a0bf-11e8-81a6-cce0f5d379f2.png)


Changes tested on the _data_ view:
![image](https://user-images.githubusercontent.com/11925502/44176251-8081fb80-a0bf-11e8-88a9-fe9ecc3fcccb.png)
